### PR TITLE
[feat] 로깅 관련 설정 추가 및 예시 코드 올립니다

### DIFF
--- a/src/main/java/com/kernel360/boogle/bookreport/controller/BookReportController.java
+++ b/src/main/java/com/kernel360/boogle/bookreport/controller/BookReportController.java
@@ -4,6 +4,8 @@ import com.kernel360.boogle.bookreport.db.BookReportEntity;
 import com.kernel360.boogle.bookreport.model.BookReportDTO;
 import com.kernel360.boogle.bookreport.service.BookReportService;
 import io.swagger.annotations.Api;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.ModelAndView;
@@ -11,6 +13,8 @@ import org.springframework.web.servlet.ModelAndView;
 @Api(tags = {"독후감 관련 API"})
 @RestController
 public class BookReportController {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private final BookReportService bookReportService;
 
     public BookReportController(BookReportService bookReportService) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  profiles:
+    active: local
   flyway:
     enabled: true
     baseline-on-migrate: true
@@ -32,3 +34,12 @@ thymeleaf:
   prefix: classpath:/templates/
   suffix: .html
   enabled: true
+
+logging:
+  file:
+    path: ./logs
+    name: log
+  logback:
+    rollingpolicy:
+      max-history: 20
+      total-size-cap: 100MB

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
+
+    <property name="CONSOLE_LOG_PATTERN"
+              value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative]  %clr(%-5level) %clr(${PID:-}){magenta} %clr(---){faint}
+              %clr([%15.15thread]){faint} %clr(%-40.40logger{36}){cyan} %clr(:){faint} %msg%n"/>
+    <property name="FILE_LOG_PATTERN"
+              value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative] %-5level ${PID:-} --- [%15.15thread] %-40.40logger{36} : %msg%n"/>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>${CONSOLE_LOG_PATTERN}</Pattern>
+        </layout>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/${LOG_FILE}.%d{yyyy-MM-dd}-%i.log</fileNamePattern>
+            <maxHistory>${LOGBACK_ROLLINGPOLICY_MAX_HISTORY}</maxHistory>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>${LOGBACK_ROLLINGPOLICY_TOTAL_SIZE_CAP}</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+        </rollingPolicy>
+    </appender>
+
+    <!--  local 환경  -->
+    <springProfile name="local">
+        <root level="debug">
+            <appender-ref ref="STDOUT" />
+            <appender-ref ref="FILE" />
+        </root>
+    </springProfile>
+    <!--  local 환경  -->
+    <springProfile name="test">
+    </springProfile>
+</configuration>


### PR DESCRIPTION
- 로깅 관련 설정 추가
   - application.yml
   - logback-spring.xml
- 예시 코드
   - BookReportController.java 에서 선언 방식 확인 가능 
   - 이후, logger.info()와 같이 다양한 레벨에서 로그 남길 수 있음 
   - boogle 프로젝트 하위 logs 폴더에 log.2023-11-09-0.log 와 같은 형태의 파일이 생성됨
     (0은 최대 파일 크기를 넘기면 1, 2, 3 .. 처럼 점점 올라감 / 현재 세팅은 파일당 최대 100MB로 되어있음)