### PR TITLE
[feat & refactor] Reply(댓글) 구현 고도화 및 Reply관련 리팩토링

### DIFF
--- a/src/main/java/com/kernel360/boogle/global/GlobalExceptionHandler.java
+++ b/src/main/java/com/kernel360/boogle/global/GlobalExceptionHandler.java
@@ -1,0 +1,17 @@
+package com.kernel360.boogle.global;
+
+import com.kernel360.boogle.reply.exception.EmptyContentException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(EmptyContentException.class)
+    public ResponseEntity<Object> handleEmptyContentException(EmptyContentException ex) {
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/kernel360/boogle/global/config/SpringSecurityConfig.java
+++ b/src/main/java/com/kernel360/boogle/global/config/SpringSecurityConfig.java
@@ -52,8 +52,9 @@ public class SpringSecurityConfig extends WebSecurityConfigurerAdapter {
 
         http.authorizeRequests()
                 .antMatchers("/", "/book-reports", "/signup", "/login", "/books").permitAll()
-                .antMatchers("/my-book-reports", "/book-report", "/reply", "/book", "/mypage/**" ).hasRole("USER")
+                .antMatchers("/my-book-reports", "/book", "/mypage/**" ).hasRole("USER")
                 .antMatchers("/admin/**").hasRole("ADMIN")
+                .antMatchers("/book-report", "/reply").hasAnyRole("USER", "ADMIN")
                 .anyRequest().authenticated();
 
         http.formLogin()

--- a/src/main/java/com/kernel360/boogle/reply/controller/ReplyController.java
+++ b/src/main/java/com/kernel360/boogle/reply/controller/ReplyController.java
@@ -43,7 +43,7 @@ public class ReplyController {
 
     @DeleteMapping("/reply")
     public void deleteReply(@RequestBody ReplyDTO reply) {
-        logger.info("댓글 삭제가 수행됨. 삭제된 댓글 정보: " + replyService.getReplyById(reply.getId()));
+        logger.info("댓글/대댓글 삭제가 수행됨. 삭제된 댓글 정보: " + replyService.getReplyById(reply.getId()) + " 추가로 삭제된 대댓글 정보: " + replyService.getRepliesByParentReplyId(reply.getId()));
         replyService.deleteReply(reply);
     }
 }

--- a/src/main/java/com/kernel360/boogle/reply/controller/ReplyController.java
+++ b/src/main/java/com/kernel360/boogle/reply/controller/ReplyController.java
@@ -1,10 +1,13 @@
 package com.kernel360.boogle.reply.controller;
 
+import com.kernel360.boogle.member.db.MemberEntity;
+import com.kernel360.boogle.reply.exception.EmptyContentException;
 import com.kernel360.boogle.reply.model.ReplyDTO;
 import com.kernel360.boogle.reply.service.ReplyService;
 import io.swagger.annotations.Api;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Api(tags = {"댓글 관련 API"})
@@ -20,18 +23,27 @@ public class ReplyController {
     private final ReplyService replyService;
 
     @PostMapping("/reply")
-    public void createReply(@RequestBody ReplyDTO reply) {
-        replyService.createReply(reply);
+    public void createReply(@RequestBody ReplyDTO reply, @AuthenticationPrincipal MemberEntity member) {
+        try {
+            replyService.createReply(reply, member);
+        } catch (EmptyContentException e) {
+            throw e;
+        }
     }
 
     @PatchMapping("/reply")
-    public void updateReply(@RequestBody ReplyDTO reply) {
-        replyService.updateReply(reply);
+    public void updateReply(@RequestBody ReplyDTO reply, @AuthenticationPrincipal MemberEntity member) {
+        logger.info("댓글 수정이 수행됨. 수정 전 댓글 정보: " + replyService.getReplyById(reply.getReplyEntity().getId()) + " 수정 후 댓글 정보: " + reply.getReplyEntity());
+        try {
+            replyService.updateReply(reply, member);
+        } catch (EmptyContentException e) {
+            throw e;
+        }
     }
 
     @DeleteMapping("/reply")
     public void deleteReply(@RequestBody ReplyDTO reply) {
+        logger.info("댓글 삭제가 수행됨. 삭제된 댓글 정보: " + replyService.getReplyById(reply.getId()));
         replyService.deleteReply(reply);
-        logger.info("댓글 삭제가 정상적으로 수행됨.");
     }
 }

--- a/src/main/java/com/kernel360/boogle/reply/db/ReplyEntity.java
+++ b/src/main/java/com/kernel360/boogle/reply/db/ReplyEntity.java
@@ -2,6 +2,7 @@ package com.kernel360.boogle.reply.db;
 
 
 import com.kernel360.boogle.bookreport.db.BookReportEntity;
+import com.kernel360.boogle.member.db.MemberEntity;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -25,10 +26,9 @@ public class ReplyEntity {
     @Column(name = "id", nullable = false)
     private Long id;
 
-    //    @ManyToOne (멤버 엔티티 생성 이후 주석 해제 필요)
-    //    @JoinColumn(name = "member_id", nullable = false)
-    @Column(name = "member_id")
-    private Long memberId;
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private MemberEntity memberEntity;
 
     @ManyToOne
     @JoinColumn(name = "book_report_id", nullable = false)

--- a/src/main/java/com/kernel360/boogle/reply/db/ReplyRepository.java
+++ b/src/main/java/com/kernel360/boogle/reply/db/ReplyRepository.java
@@ -15,8 +15,7 @@ public interface ReplyRepository extends JpaRepository<ReplyEntity, Long> {
 
     Optional<List<ReplyEntity>> findAllByParentReplyId(Long parentReplyId);
 
-
-    List<ReplyEntity> findAllByMemberId(Long MemberId);
+    List<ReplyEntity> findAllByMemberEntityId(Long MemberId);
 
     void deleteById(Long id);
 }

--- a/src/main/java/com/kernel360/boogle/reply/db/ReplyRepository.java
+++ b/src/main/java/com/kernel360/boogle/reply/db/ReplyRepository.java
@@ -15,7 +15,7 @@ public interface ReplyRepository extends JpaRepository<ReplyEntity, Long> {
 
     Optional<List<ReplyEntity>> findAllByParentReplyId(Long parentReplyId);
 
-    List<ReplyEntity> findAllByMemberEntityId(Long MemberId);
+    List<ReplyEntity> findAllByMemberEntityIdOrderByCreatedAtDesc(Long MemberId);
 
     void deleteById(Long id);
 }

--- a/src/main/java/com/kernel360/boogle/reply/exception/EmptyContentException.java
+++ b/src/main/java/com/kernel360/boogle/reply/exception/EmptyContentException.java
@@ -1,0 +1,12 @@
+package com.kernel360.boogle.reply.exception;
+
+public class EmptyContentException extends IllegalArgumentException {
+
+    public EmptyContentException() {
+        super("공백은 입력될 수 없습니다.");
+    }
+
+    public EmptyContentException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/kernel360/boogle/reply/model/ReplyDTO.java
+++ b/src/main/java/com/kernel360/boogle/reply/model/ReplyDTO.java
@@ -1,6 +1,7 @@
 package com.kernel360.boogle.reply.model;
 
 import com.kernel360.boogle.bookreport.db.BookReportEntity;
+import com.kernel360.boogle.member.db.MemberEntity;
 import com.kernel360.boogle.reply.db.ReplyEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,8 +15,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class ReplyDTO {
     private Long id;
-//    private MemberEntity memberEntity;
-    private Long memberId;
+    private MemberEntity memberEntity;
     private BookReportEntity bookReportEntity;
     private String content;
     private Long parentReplyId;
@@ -26,7 +26,7 @@ public class ReplyDTO {
     public static ReplyDTO from(ReplyEntity replyEntity) {
         return new ReplyDTO(
                 replyEntity.getId(),
-                replyEntity.getMemberId(),
+                replyEntity.getMemberEntity(),
                 replyEntity.getBookReportEntity(),
                 replyEntity.getContent(),
                 replyEntity.getParentReplyId(),

--- a/src/main/java/com/kernel360/boogle/reply/model/ReplyResponse.java
+++ b/src/main/java/com/kernel360/boogle/reply/model/ReplyResponse.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 public record ReplyResponse(
         Long id,
         Long memberId,
+        String memberNickname,
         Long bookReportId,
         String bookReportCreatedBy,
         String content,
@@ -16,20 +17,23 @@ public record ReplyResponse(
         LocalDateTime createdAt,
         LocalDateTime lastModifiedAt
 ) {
-    private static ReplyResponse of(Long id, Long memberId, Long bookReportId, String bookReportCreatedBy, String content, Long parentReplyId, LocalDateTime createdAt, LocalDateTime lastModifiedAt) {
+    private static ReplyResponse of(Long id, Long memberId, String memberNickname, Long bookReportId, String bookReportCreatedBy, String content, Long parentReplyId, LocalDateTime createdAt, LocalDateTime lastModifiedAt) {
         Comparator<ReplyResponse> childRepliesComparator = Comparator
                 .comparing(ReplyResponse::createdAt)
                 .thenComparingLong(ReplyResponse::id);
-        return new ReplyResponse(id, memberId, bookReportId, bookReportCreatedBy, content, parentReplyId, new TreeSet<>(childRepliesComparator), createdAt, lastModifiedAt);
+        return new ReplyResponse(id, memberId, memberNickname, bookReportId, bookReportCreatedBy, content, parentReplyId, new TreeSet<>(childRepliesComparator), createdAt, lastModifiedAt);
     }
 
     public static ReplyResponse from(ReplyDTO replyDTO) {
+        Long memberId = replyDTO.getMemberEntity().getId();
+        String memberNickname = replyDTO.getMemberEntity().getNickname();
         Long bookReportId = replyDTO.getBookReportEntity().getId();
         String bookReportCreatedBy = replyDTO.getBookReportEntity().getCreatedBy();
 
         return ReplyResponse.of(
                 replyDTO.getId(),
-                replyDTO.getMemberId(),
+                memberId,
+                memberNickname,
                 bookReportId,
                 bookReportCreatedBy,
                 replyDTO.getContent(),

--- a/src/main/java/com/kernel360/boogle/reply/service/ReplyService.java
+++ b/src/main/java/com/kernel360/boogle/reply/service/ReplyService.java
@@ -67,10 +67,9 @@ public class ReplyService {
     }
 
     public Optional<List<ReplyDTO>> getRecentRepliesByMemberId(Long memberId, int cnt) {
-        return Optional.of(replyRepository.findAllByMemberEntityId(memberId)
+        return Optional.of(replyRepository.findAllByMemberEntityIdOrderByCreatedAtDesc(memberId)
                 .stream()
                 .map(ReplyDTO::from)
-                .sorted((r1, r2) -> r2.getCreatedAt().compareTo(r1.getCreatedAt()))
                 .limit(cnt)
                 .toList());
     }

--- a/src/main/java/com/kernel360/boogle/reply/service/ReplyService.java
+++ b/src/main/java/com/kernel360/boogle/reply/service/ReplyService.java
@@ -48,6 +48,10 @@ public class ReplyService {
                 .toList());
     }
 
+    public Optional<List<ReplyEntity>> getRepliesByParentReplyId(Long parentReplyId) {
+        return replyRepository.findAllByParentReplyId(parentReplyId);
+    }
+
     public void updateReply(ReplyDTO reply, @AuthenticationPrincipal MemberEntity member) {
 
         if (reply.getReplyEntity().getContent().replaceAll("\\s", "").equals("")) {

--- a/src/main/java/com/kernel360/boogle/reply/service/ReplyService.java
+++ b/src/main/java/com/kernel360/boogle/reply/service/ReplyService.java
@@ -2,8 +2,12 @@ package com.kernel360.boogle.reply.service;
 
 import com.kernel360.boogle.bookreport.db.BookReportEntity;
 import com.kernel360.boogle.bookreport.db.BookReportRepository;
+import com.kernel360.boogle.member.db.MemberEntity;
+import com.kernel360.boogle.reply.db.ReplyEntity;
 import com.kernel360.boogle.reply.db.ReplyRepository;
+import com.kernel360.boogle.reply.exception.EmptyContentException;
 import com.kernel360.boogle.reply.model.ReplyDTO;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,9 +26,18 @@ public class ReplyService {
         this.bookReportRepository = bookReportRepository;
     }
 
-    public void createReply(ReplyDTO reply) {
-        reply.getReplyEntity().setMemberId(1L); // 로그인 사용자 정보 들어가야 함.
+    public void createReply(ReplyDTO reply, @AuthenticationPrincipal MemberEntity member) {
+
+        if (reply.getReplyEntity().getContent().replaceAll("\\s", "").equals("")) {
+            throw new EmptyContentException();
+        }
+
+        reply.getReplyEntity().setMemberEntity(member);
         replyRepository.save(reply.getReplyEntity());
+    }
+
+    public Optional<ReplyEntity> getReplyById(Long id) {
+        return replyRepository.findById(id);
     }
 
     public Optional<List<ReplyDTO>> getRepliesByBookReportId(Long bookReportId) {
@@ -35,7 +48,13 @@ public class ReplyService {
                 .toList());
     }
 
-    public void updateReply(ReplyDTO reply) {
+    public void updateReply(ReplyDTO reply, @AuthenticationPrincipal MemberEntity member) {
+
+        if (reply.getReplyEntity().getContent().replaceAll("\\s", "").equals("")) {
+            throw new EmptyContentException();
+        }
+
+        reply.getReplyEntity().setMemberEntity(member);
         replyRepository.save(reply.getReplyEntity());
     }
 
@@ -44,7 +63,7 @@ public class ReplyService {
     }
 
     public Optional<List<ReplyDTO>> getRecentRepliesByMemberId(Long memberId, int cnt) {
-        return Optional.of(replyRepository.findAllByMemberId(memberId)
+        return Optional.of(replyRepository.findAllByMemberEntityId(memberId)
                 .stream()
                 .map(ReplyDTO::from)
                 .sorted((r1, r2) -> r2.getCreatedAt().compareTo(r1.getCreatedAt()))

--- a/src/main/resources/templates/bookreport/book-report-detail.html
+++ b/src/main/resources/templates/bookreport/book-report-detail.html
@@ -29,11 +29,57 @@
             if (xhr.status === 200) {
                 alert('댓글이 생성되었습니다.');
                 window.location.href = '/book-report?id=' + document.getElementById('bookReportId').value;
+            } else if (xhr.status === 400) {
+                alert('댓글 생성 중 오류가 발생했습니다: ' + xhr.responseText);
             } else {
                 alert('댓글 생성 중 오류가 발생했습니다.');
             }
         };
         xhr.send(JSON.stringify(data));
+    }
+
+    function showUpdateForm(replyId, currentContent, isChildReply) {
+        if (isChildReply) {
+            document.getElementById(`update-child-reply-textbox-${replyId}`).value = currentContent;
+            document.getElementById(`update-child-reply-form-${replyId}`).style.display = 'block';
+        } else {
+            document.getElementById(`update-reply-textbox-${replyId}`).value = currentContent;
+            document.getElementById(`update-reply-form-${replyId}`).style.display = 'block';
+        }
+    }
+
+    async function updateReply(replyId, isChildReply) {
+        let data = {
+            replyEntity: {
+                id: replyId,
+                bookReportEntity: { id: document.getElementById('bookReportId').value },
+                content: isChildReply
+                    ? document.getElementById(`update-child-reply-textbox-${replyId}`).value
+                    : document.getElementById(`update-reply-textbox-${replyId}`).value,
+                parentReplyId: isChildReply ? document.getElementById('check-parent-reply-id-' + replyId).value : null
+            }
+        };
+
+        try {
+            const response = await fetch('/reply', {
+                method: 'PATCH',
+                headers: {
+                    'Content-Type': 'application/json; charset=UTF-8',
+                },
+                body: JSON.stringify(data),
+            });
+
+            if (response.ok) {
+                alert('댓글이 수정되었습니다.');
+                window.location.href = '/book-report?id=' + document.getElementById('bookReportId').value;
+            } else {
+                const errorMessage = await response.text();
+                alert('댓글 수정 중 오류가 발생했습니다: ' + errorMessage);
+            }
+        } catch (error) {
+            console.error('댓글 수정 중 오류가 발생했습니다.', error);
+            alert('댓글 수정 중 오류가 발생했습니다.');
+        }
     }
 
     async function deleteBookReport(bookReportId) {
@@ -151,7 +197,7 @@
                     <!-- Add more content placeholders as needed -->
                 </section>
 
-                <form class="reply-form" th:action="@{/reply}" th:method="post">
+                <form class="row reply-form" th:action="@{/reply}" th:method="post">
                     <input type="hidden" class="book-report-id" th:name="bookReportId" th:value="${bookReport.id}" />
                     <div class="col-md-9 col-lg-8">
                         <label for="reply-textbox" hidden>댓글</label>
@@ -162,17 +208,24 @@
                         <button class="btn btn-primary" id="reply-submit" type="button" th:onclick="|createReply(false);|">쓰기</button>
                     </div>
                 </form>
-                <ul id="article-replys" class="row col-md-10 col-lg-8 pt-3">
+                <ul id="article-replys" class="row col-md-11 col-lg-10 pt-3">
                     <li class="parent-reply" th:each="reply, replyIndex : ${replies}">
                         <form class="reply-delete-form">
                             <input type="hidden" class="book-report-id" th:name="id" th:value="${bookReport.id}" />
                             <div class="row">
                                 <div class="col-md-10 col-lg-9">
-                                    <strong th:text="${reply.memberId}"></strong>
+                                    <strong th:text="${reply.memberNickname}"></strong>
                                     <small><time th:datetime="${#temporals.format(reply.createdAt, 'yyyy-MM-dd HH:mm:ss')}" th:text="${#temporals.format(reply.createdAt, 'yyyy-MM-dd HH:mm:ss')}"></time></small>
                                     <p class="mb-1" th:text="${reply.content}"></p>
+                                    <div th:id="'update-reply-form-' + ${reply.id}" style="display: none;">
+                                        <textarea class="form-control reply-textbox" th:id="'update-reply-textbox-' + ${reply.id}" rows="3" required></textarea>
+                                        <button class="btn btn-primary" type="submit" th:onclick="|updateReply(${reply.id}, false);|">수정 완료</button>
+                                    </div>
                                 </div>
-                                <div class="col-2 mb-3 align-self-center">
+                                <div class="col-2 mb-3 align-self-center" th:if="${#authorization.expression('isAuthenticated()')} and ${reply.memberId} == ${#authentication.principal.id}">
+                                    <button type="button" class="btn btn-outline-primary"
+                                            th:attr="data-reply-id=${reply.id}, data-reply-content=${reply.content}"
+                                            th:onclick="|showUpdateForm(this.getAttribute('data-reply-id'), this.getAttribute('data-reply-content'), false);|">수정</button>
                                     <button type="submit" class="btn btn-outline-danger" th:onclick="|deleteReply(${reply.id});|">삭제</button>
                                 </div>
                             </div>
@@ -183,11 +236,19 @@
                                     <input type="hidden" class="book-report-id" th:name="id" th:value="${bookReport.id}" />
                                     <div class="row">
                                         <div class="col-md-10 col-lg-9">
-                                            <strong th:text="${childReply.memberId}"></strong>
+                                            <strong th:text="${childReply.memberNickname}"></strong>
                                             <small><time th:datetime="${#temporals.format(childReply.createdAt, 'yyyy-MM-dd HH:mm:ss')}" th:text="${#temporals.format(childReply.createdAt, 'yyyy-MM-dd HH:mm:ss')}"></time></small>
                                             <p class="mb-1" th:text="${childReply.content}"></p>
+                                            <div th:id="'update-child-reply-form-' + ${childReply.id}" style="display: none;">
+                                                <textarea class="form-control reply-textbox" th:id="'update-child-reply-textbox-' + ${childReply.id}" rows="3" required></textarea>
+                                                <input type="hidden" th:id="'check-parent-reply-id-' + ${childReply.id}" th:value="${reply.id}">
+                                                <button class="btn btn-primary" type="submit" th:onclick="|updateReply(${childReply.id}, true);|">수정 완료</button>
+                                            </div>
                                         </div>
-                                        <div class="col-2 mb-3 align-self-center">
+                                        <div class="col-2 mb-3 align-self-center" th:if="${#authorization.expression('isAuthenticated()')} and ${childReply.memberId} == ${#authentication.principal.id}">
+                                            <button type="button" class="btn btn-outline-primary"
+                                                    th:attr="data-child-reply-id=${childReply.id}, data-child-reply-content=${childReply.content}"
+                                                    th:onclick="|showUpdateForm(this.getAttribute('data-child-reply-id'), this.getAttribute('data-child-reply-content'), true);|">수정</button>
                                             <button type="submit" class="btn btn-outline-danger" th:onclick="|deleteReply(${childReply.id});|">삭제</button>
                                         </div>
                                     </div>


### PR DESCRIPTION
[feat]
- ReplyEntity에 memberEntity(생성자) 연결
- 댓글 생성/수정 시, 현재 로그인된 유저 정보 연결
- 생성 및 수정에서 custom exception(빈칸 or 공백으로만 댓글 입력) 추가
- 댓글 수정/삭제 시, 로깅
  - 댓글 수정 시, 수정 전/후 댓글 모두 로그에 남도록 했습니다.
  - 댓글 삭제 시, 
    - 어떤 댓글/대댓글이 삭제되는지, 
    - 부모댓글 삭제에 따라 추가로 삭제되는 자녀댓글(대댓글)에 대해서도 삭제 로그가 남도록 했습니다. 
- Reply(댓글) 수정버튼 프론트 구현

[refactor]
- SpringSecurityConfig Role별 권한 설정 리팩토링
- ReplyEntity 변경에 따른 마이페이지용 Spring Data JPA 수정
  - MyPage(마이페이지) '내가 쓴 댓글보기' 최신순 정렬에 Spring Data JPA 활용
  - Service에서 수행되던 것을 Spring Data JPA(OrderByCreatedAtDesc)을 추가하여 Repository에서 수행되도록 수정했습니다.