### PR TITLE
[feat & refactor] 

### DIFF
--- a/src/main/java/com/kernel360/boogle/book/controller/BookAdminController.java
+++ b/src/main/java/com/kernel360/boogle/book/controller/BookAdminController.java
@@ -6,6 +6,7 @@ import com.kernel360.boogle.book.model.BookSearchType;
 import com.kernel360.boogle.book.model.BookViewRequest;
 import com.kernel360.boogle.book.service.BookService;
 import com.kernel360.boogle.member.db.MemberEntity;
+import com.kernel360.boogle.member.model.MemberDTO;
 import io.swagger.annotations.Api;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -38,7 +39,7 @@ public class BookAdminController {
 
     @PostMapping("/admin/book")
     public void createBook(@RequestBody BookDTO book, @AuthenticationPrincipal MemberEntity memberEntity) {
-        bookService.createBook(book, memberEntity);
+        bookService.createBook(book, MemberDTO.from(memberEntity));
     }
 
     @PreAuthorize("hasRole('USER')")
@@ -74,8 +75,8 @@ public class BookAdminController {
     }
 
     @PatchMapping("/admin/book")
-    public void updateBook(@RequestBody BookDTO book, @AuthenticationPrincipal MemberEntity member) {
-        bookService.updateBook(book, member);
+    public void updateBook(@RequestBody BookDTO book, @AuthenticationPrincipal MemberEntity memberEntity) {
+        bookService.updateBook(book, MemberDTO.from(memberEntity));
     }
 
     @DeleteMapping("/admin/book")

--- a/src/main/java/com/kernel360/boogle/book/controller/BookAdminController.java
+++ b/src/main/java/com/kernel360/boogle/book/controller/BookAdminController.java
@@ -5,14 +5,18 @@ import com.kernel360.boogle.book.model.BookDTO;
 import com.kernel360.boogle.book.model.BookSearchType;
 import com.kernel360.boogle.book.model.BookViewRequest;
 import com.kernel360.boogle.book.service.BookService;
+import com.kernel360.boogle.member.db.MemberEntity;
 import io.swagger.annotations.Api;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.ModelAndView;
 
 @Api(tags = {"도서 관련 Admin API"})
 @RestController
+@Slf4j
 public class BookAdminController {
 
     private final BookService bookService;
@@ -33,8 +37,8 @@ public class BookAdminController {
     }
 
     @PostMapping("/admin/book")
-    public void createBook(@RequestBody BookDTO book) {
-        bookService.createBook(book);
+    public void createBook(@RequestBody BookDTO book, @AuthenticationPrincipal MemberEntity memberEntity) {
+        bookService.createBook(book, memberEntity);
     }
 
     @PreAuthorize("hasRole('USER')")
@@ -70,14 +74,13 @@ public class BookAdminController {
     }
 
     @PatchMapping("/admin/book")
-    public void updateBook(@RequestBody BookDTO book) {
-        bookService.updateBook(book);
+    public void updateBook(@RequestBody BookDTO book, @AuthenticationPrincipal MemberEntity member) {
+        bookService.updateBook(book, member);
     }
 
-    @PatchMapping("/admin/book/delete")
-    public String deleteBook(
-            @RequestBody BookViewRequest bookViewRequest
-    ) {
+    @DeleteMapping("/admin/book")
+    public String deleteBook(@RequestBody BookViewRequest bookViewRequest) {
+        log.info("도서 삭제가 수행됨. 삭제된 도서 정보: " + bookService.getBookById(bookViewRequest.getId()));
         bookService.deleteBook(bookViewRequest);
         return "redirect:/admin/books";
     }

--- a/src/main/java/com/kernel360/boogle/book/db/BookRepository.java
+++ b/src/main/java/com/kernel360/boogle/book/db/BookRepository.java
@@ -19,4 +19,5 @@ public interface BookRepository extends JpaRepository<BookEntity, Long> {
     Page<BookEntity> findBookEntitiesByPublisherContainingOrderByIdDesc(String publisher, Pageable pageable);
     Optional<BookEntity> findById(Long bookId);
     Page<BookEntity> findAllByOrderByIdDesc(Pageable pageable);
+    void deleteById(Long id);
 }

--- a/src/main/java/com/kernel360/boogle/book/model/BookDTO.java
+++ b/src/main/java/com/kernel360/boogle/book/model/BookDTO.java
@@ -28,7 +28,5 @@ public class BookDTO {
     private LocalDateTime createdAt;
     private String lastModifiedBy;
     private LocalDateTime lastModifiedAt;
-    private String isDeleted;
-    private LocalDateTime deletedAt;
     private BookEntity bookEntity;
 }

--- a/src/main/java/com/kernel360/boogle/book/service/BookService.java
+++ b/src/main/java/com/kernel360/boogle/book/service/BookService.java
@@ -4,14 +4,16 @@ import com.kernel360.boogle.book.db.BookEntity;
 import com.kernel360.boogle.book.db.BookRepository;
 import com.kernel360.boogle.book.model.BookDTO;
 import com.kernel360.boogle.book.model.BookViewRequest;
+import com.kernel360.boogle.member.db.MemberEntity;
+import com.kernel360.boogle.member.model.MemberDTO;
 import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
-import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Service
@@ -22,8 +24,8 @@ public class BookService {
     private final BookRepository bookRepository;
     private static final Integer PAGE_SIZE = 6;
 
-    public void createBook(BookDTO book) {
-        book.getBookEntity().setCreatedBy("TEST"); // 로그인 사용자 정보 들어가야 함
+    public void createBook(BookDTO book, MemberEntity memberEntity) {
+        book.getBookEntity().setCreatedBy(memberEntity.getEmail());
         bookRepository.save(book.getBookEntity());
     }
 
@@ -52,19 +54,13 @@ public class BookService {
         return bookRepository.findBookEntitiesByPublisherContainingOrderByIdDesc(searchWord, pageable);
     }
 
-    public void updateBook(BookDTO book) {
-        book.getBookEntity().setLastModifiedBy("TEST"); // 로그인 사용자 정보 들어가야함
+    public void updateBook(BookDTO book, @AuthenticationPrincipal MemberEntity member) {
+        book.getBookEntity().setLastModifiedBy(member.getEmail());
         bookRepository.save(book.getBookEntity());
     }
 
     public void deleteBook(BookViewRequest bookViewRequest) {
-        bookRepository.findById(bookViewRequest.getId())
-                .map(
-                        it -> {
-                            bookRepository.save(it);
-                            return it;
-                        }
-                );
+        bookRepository.deleteById(bookViewRequest.getId());
     }
 
 

--- a/src/main/java/com/kernel360/boogle/book/service/BookService.java
+++ b/src/main/java/com/kernel360/boogle/book/service/BookService.java
@@ -4,13 +4,11 @@ import com.kernel360.boogle.book.db.BookEntity;
 import com.kernel360.boogle.book.db.BookRepository;
 import com.kernel360.boogle.book.model.BookDTO;
 import com.kernel360.boogle.book.model.BookViewRequest;
-import com.kernel360.boogle.member.db.MemberEntity;
 import com.kernel360.boogle.member.model.MemberDTO;
 import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
@@ -24,8 +22,8 @@ public class BookService {
     private final BookRepository bookRepository;
     private static final Integer PAGE_SIZE = 6;
 
-    public void createBook(BookDTO book, MemberEntity memberEntity) {
-        book.getBookEntity().setCreatedBy(memberEntity.getEmail());
+    public void createBook(BookDTO book, MemberDTO memberDTO) {
+        book.getBookEntity().setCreatedBy(memberDTO.getEmail());
         bookRepository.save(book.getBookEntity());
     }
 
@@ -54,8 +52,8 @@ public class BookService {
         return bookRepository.findBookEntitiesByPublisherContainingOrderByIdDesc(searchWord, pageable);
     }
 
-    public void updateBook(BookDTO book, @AuthenticationPrincipal MemberEntity member) {
-        book.getBookEntity().setLastModifiedBy(member.getEmail());
+    public void updateBook(BookDTO book, MemberDTO memberDTO) {
+        book.getBookEntity().setLastModifiedBy(memberDTO.getEmail());
         bookRepository.save(book.getBookEntity());
     }
 

--- a/src/main/java/com/kernel360/boogle/bookreport/controller/BookReportAdminController.java
+++ b/src/main/java/com/kernel360/boogle/bookreport/controller/BookReportAdminController.java
@@ -4,12 +4,14 @@ import com.kernel360.boogle.bookreport.db.BookReportEntity;
 import com.kernel360.boogle.bookreport.model.BookReportDTO;
 import com.kernel360.boogle.bookreport.service.BookReportService;
 import io.swagger.annotations.Api;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.ModelAndView;
 
 @Api(tags = {"독후감 관련 Admin API"})
 @RestController
+@Slf4j
 public class BookReportAdminController {
 
     private final BookReportService bookReportService;
@@ -39,8 +41,9 @@ public class BookReportAdminController {
         return mv;
     }
 
-    @PatchMapping("admin/book-report/delete")
+    @DeleteMapping("admin/book-report")
     public void deleteBookReport(@RequestBody BookReportDTO bookReport) {
+        log.info("ADMIN에 의해 독후감 삭제가 수행됨. 삭제된 독후감 정보: " + bookReportService.getBookReportById(bookReport.getId()));
         bookReportService.deleteBookReport(bookReport.getId());
     }
 

--- a/src/main/java/com/kernel360/boogle/bookreport/controller/BookReportController.java
+++ b/src/main/java/com/kernel360/boogle/bookreport/controller/BookReportController.java
@@ -7,6 +7,7 @@ import com.kernel360.boogle.reply.model.ReplyDTO;
 import com.kernel360.boogle.reply.model.ReplyResponse;
 import com.kernel360.boogle.reply.service.ReplyService;
 import io.swagger.annotations.Api;
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
@@ -17,6 +18,7 @@ import java.util.List;
 
 @Api(tags = {"독후감 관련 API"})
 @RestController
+@Slf4j
 public class BookReportController {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
@@ -93,8 +95,9 @@ public class BookReportController {
         bookReportService.updateBookReport(bookReport);
     }
 
-    @PatchMapping("/book-report/delete")
+    @DeleteMapping("/book-report")
     public void deleteBookReport(@RequestBody BookReportDTO bookReport) {
+        log.info("USER에 의해 독후감 삭제가 수행됨. 삭제된 독후감 정보: " + bookReportService.getBookReportById(bookReport.getId()));
         bookReportService.deleteBookReport(bookReport.getId());
     }
 }

--- a/src/main/java/com/kernel360/boogle/bookreport/db/BookReportEntity.java
+++ b/src/main/java/com/kernel360/boogle/bookreport/db/BookReportEntity.java
@@ -56,10 +56,4 @@ public class BookReportEntity {
     @LastModifiedDate
     @Column(name = "last_modified_at", columnDefinition = "DATETIME")
     private LocalDateTime lastModifiedAt;
-
-    @Column(name = "is_deleted")
-    private String isDeleted = "N";
-
-    @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
 }

--- a/src/main/java/com/kernel360/boogle/bookreport/db/BookReportRepository.java
+++ b/src/main/java/com/kernel360/boogle/bookreport/db/BookReportRepository.java
@@ -10,16 +10,17 @@ import java.util.Optional;
 public interface BookReportRepository extends JpaRepository<BookReportEntity, Long> {
     BookReportEntity save(BookReportEntity bookReport);
 
-    Page<BookReportEntity> findAllByIsPublicEqualsAndIsDeletedNotOrderByIdDesc(String isPublic, String isDeleted, Pageable pageable);
+    Page<BookReportEntity> findAllByIsPublicOrderByIdDesc(String isPublic, Pageable pageable);
 
-    Page<BookReportEntity> findAllByMemberIdEqualsAndIsDeletedNotOrderByIdDesc(Long memberId, String isDeleted, Pageable pageable);
+    Page<BookReportEntity> findAllByMemberIdOrderByIdDesc(Long memberId, Pageable pageable);
 
-    Page<BookReportEntity> findAllByIsDeletedNotOrderByIdDesc(String isDeleted, Pageable pageable);
+    Page<BookReportEntity> findAllByOrderByIdDesc(Pageable pageable);
 
     Optional<BookReportEntity> findById(Long bookReportId);
 
-    List<BookReportEntity> findAllByBookEntity_IdAndIsDeletedAndIsPublicOrderByCreatedAtDesc(Long bookId, String isDelete, String isPublic);
+    List<BookReportEntity> findAllByBookEntity_IdAndIsPublicOrderByCreatedAtDesc(Long bookId, String isPublic);
 
     List<BookReportEntity> findAllByMemberId(Long MemberId);
 
+    void deleteById(Long id);
 }

--- a/src/main/java/com/kernel360/boogle/bookreport/model/BookReportDTO.java
+++ b/src/main/java/com/kernel360/boogle/bookreport/model/BookReportDTO.java
@@ -25,7 +25,5 @@ public class BookReportDTO {
     private LocalDateTime createdAt;
     private String lastModifiedBy;
     private LocalDateTime lastModifiedAt;
-    private String isDeleted;
-    private LocalDateTime deletedAt;
     private BookReportEntity bookReportEntity;
 }

--- a/src/main/java/com/kernel360/boogle/bookreport/service/BookReportService.java
+++ b/src/main/java/com/kernel360/boogle/bookreport/service/BookReportService.java
@@ -37,21 +37,21 @@ public class BookReportService {
 
     public Page<BookReportEntity> getPublicBookReports(String isPublic, int page) {
         Pageable pageable = PageRequest.of(page, PAGE_SIZE);
-        return bookReportRepository.findAllByIsPublicEqualsAndIsDeletedNotOrderByIdDesc(isPublic, "Y", pageable);
+        return bookReportRepository.findAllByIsPublicOrderByIdDesc(isPublic, pageable);
     }
 
     public Page<BookReportEntity> getMyBookReports(Long memberId, int page) {
         Pageable pageable = PageRequest.of(page, PAGE_SIZE);
-        return bookReportRepository.findAllByMemberIdEqualsAndIsDeletedNotOrderByIdDesc(memberId, "Y", pageable);
+        return bookReportRepository.findAllByMemberIdOrderByIdDesc(memberId, pageable);
     }
 
     public Page<BookReportEntity> getAllBookReports(int page) {
         Pageable pageable = PageRequest.of(page, PAGE_SIZE);
-        return bookReportRepository.findAllByIsDeletedNotOrderByIdDesc("Y", pageable);
+        return bookReportRepository.findAllByOrderByIdDesc(pageable);
     }
 
     public List<BookReportEntity> getPublicBookReportsByBookId(Long bookId) {
-        return bookReportRepository.findAllByBookEntity_IdAndIsDeletedAndIsPublicOrderByCreatedAtDesc(bookId, "N", "Y");
+        return bookReportRepository.findAllByBookEntity_IdAndIsPublicOrderByCreatedAtDesc(bookId,"Y");
     }
 
     public void updateBookReport(BookReportDTO bookReport) {
@@ -62,15 +62,7 @@ public class BookReportService {
     }
 
     public void deleteBookReport(Long bookReportId) {
-        bookReportRepository.findById(bookReportId)
-                .map(
-                        it -> {
-                            it.setIsDeleted("Y");
-                            it.setDeletedAt(LocalDateTime.now());
-                            bookReportRepository.save(it);
-                            return it;
-                        }
-                );
+        bookReportRepository.deleteById(bookReportId);
     }
 
 

--- a/src/main/java/com/kernel360/boogle/member/model/MemberDTO.java
+++ b/src/main/java/com/kernel360/boogle/member/model/MemberDTO.java
@@ -1,0 +1,46 @@
+package com.kernel360.boogle.member.model;
+
+import com.kernel360.boogle.member.db.MemberEntity;
+import com.kernel360.boogle.member.db.MemberRole;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberDTO {
+    private Long id;
+    private String email;
+    private String password;
+    private String name;
+    private String nickname;
+    private String phoneNumber;
+    private LocalDateTime signupDate;
+    private LocalDateTime withdrawalDate;
+    private String lastModifiedBy;
+    private LocalDateTime lastModifiedAt;
+    private MemberRole role;
+    private MemberEntity memberEntity;
+
+    public static MemberDTO from(MemberEntity memberEntity) {
+        return new MemberDTO(
+                memberEntity.getId(),
+                memberEntity.getEmail(),
+                memberEntity.getPassword(),
+                memberEntity.getName(),
+                memberEntity.getNickname(),
+                memberEntity.getPhoneNumber(),
+                memberEntity.getSignupDate(),
+                memberEntity.getWithdrawalDate(),
+                memberEntity.getLastModifiedBy(),
+                memberEntity.getLastModifiedAt(),
+                memberEntity.getRole(),
+                memberEntity
+        );
+    }
+}

--- a/src/main/java/com/kernel360/boogle/reply/controller/ReplyController.java
+++ b/src/main/java/com/kernel360/boogle/reply/controller/ReplyController.java
@@ -1,6 +1,7 @@
 package com.kernel360.boogle.reply.controller;
 
 import com.kernel360.boogle.member.db.MemberEntity;
+import com.kernel360.boogle.member.model.MemberDTO;
 import com.kernel360.boogle.reply.model.ReplyDTO;
 import com.kernel360.boogle.reply.service.ReplyService;
 import io.swagger.annotations.Api;
@@ -23,15 +24,16 @@ public class ReplyController {
 
     @PostMapping("/reply")
     @ApiResponses({@ApiResponse(code = 401, message = "공백은 입력될 수 없습니다.")})
-    public void createReply(@RequestBody ReplyDTO reply, @AuthenticationPrincipal MemberEntity member) {
-        replyService.createReply(reply, member);
+    public void createReply(@RequestBody ReplyDTO reply, @AuthenticationPrincipal MemberEntity memberEntity) {
+        replyService.createReply(reply, MemberDTO.from(memberEntity));
     }
 
+    @CrossOrigin
     @PatchMapping("/reply")
     @ApiResponses({@ApiResponse(code = 401, message = "공백은 입력될 수 없습니다.")})
-    public void updateReply(@RequestBody ReplyDTO reply, @AuthenticationPrincipal MemberEntity member) {
+    public void updateReply(@RequestBody ReplyDTO reply, @AuthenticationPrincipal MemberEntity memberEntity) {
         log.info("댓글 수정이 수행됨. 수정 전 댓글 정보: " + replyService.getReplyById(reply.getReplyEntity().getId()) + " 수정 후 댓글 정보: " + reply.getReplyEntity());
-        replyService.updateReply(reply, member);
+        replyService.updateReply(reply, MemberDTO.from(memberEntity));
     }
 
     @DeleteMapping("/reply")

--- a/src/main/java/com/kernel360/boogle/reply/service/ReplyService.java
+++ b/src/main/java/com/kernel360/boogle/reply/service/ReplyService.java
@@ -4,11 +4,10 @@ import com.kernel360.boogle.bookreport.db.BookReportEntity;
 import com.kernel360.boogle.bookreport.db.BookReportRepository;
 import com.kernel360.boogle.global.error.code.ReplyErrorCode;
 import com.kernel360.boogle.global.error.exception.BusinessException;
-import com.kernel360.boogle.member.db.MemberEntity;
+import com.kernel360.boogle.member.model.MemberDTO;
 import com.kernel360.boogle.reply.db.ReplyEntity;
 import com.kernel360.boogle.reply.db.ReplyRepository;
 import com.kernel360.boogle.reply.model.ReplyDTO;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,13 +22,13 @@ public class ReplyService {
     private final ReplyRepository replyRepository;
     private final BookReportRepository bookReportRepository;
 
-    public void createReply(ReplyDTO reply, @AuthenticationPrincipal MemberEntity member) {
+    public void createReply(ReplyDTO reply, MemberDTO memberDTO) {
 
         if (reply.getReplyEntity().getContent().replaceAll("\\s", "").equals("")) {
             throw new BusinessException(ReplyErrorCode.EMPTY_CONTENT_REPLY);
         }
 
-        reply.getReplyEntity().setMemberEntity(member);
+        reply.getReplyEntity().setMemberEntity(memberDTO.getMemberEntity());
         replyRepository.save(reply.getReplyEntity());
     }
 
@@ -50,13 +49,13 @@ public class ReplyService {
         return replyRepository.findAllByParentReplyId(parentReplyId);
     }
 
-    public void updateReply(ReplyDTO reply, @AuthenticationPrincipal MemberEntity member) {
+    public void updateReply(ReplyDTO reply, MemberDTO memberDTO) {
 
         if (reply.getReplyEntity().getContent().replaceAll("\\s", "").equals("")) {
             throw new BusinessException(ReplyErrorCode.EMPTY_CONTENT_REPLY);
         }
 
-        reply.getReplyEntity().setMemberEntity(member);
+        reply.getReplyEntity().setMemberEntity(memberDTO.getMemberEntity());
         replyRepository.save(reply.getReplyEntity());
     }
 

--- a/src/main/resources/db/migration/V3.0.12__alter_column_in_book.sql
+++ b/src/main/resources/db/migration/V3.0.12__alter_column_in_book.sql
@@ -1,0 +1,3 @@
+alter table BOOK
+drop column DELETED_AT,
+drop column is_deleted;

--- a/src/main/resources/db/migration/V3.0.13__alter_column_in_book_report.sql
+++ b/src/main/resources/db/migration/V3.0.13__alter_column_in_book_report.sql
@@ -1,0 +1,3 @@
+alter table BOOK_REPORT
+drop column deleted_at,
+drop column is_deleted;

--- a/src/main/resources/templates/book/admin/book-update.html
+++ b/src/main/resources/templates/book/admin/book-update.html
@@ -77,7 +77,7 @@
       xhr.onload = function() {
         if (xhr.status === 200) {
           alert('도서 정보가 수정되었습니다.');
-          window.location.href = '/admin/books'; // 정상적으로 변경 후, 메인페이지로 이동
+          window.location.href = '/admin/books';
 
         } else {
           alert('도서 정보 수정 중 오류가 발생했습니다.');
@@ -87,7 +87,7 @@
       xhr.send(JSON.stringify(data));
     }
     function cancel() {
-      window.location.href = '/admin/books'; // 취소 버튼 누를 때 메인 페이지로 이동
+      window.location.href = '/admin/books';
     }
   </script>
 </head>

--- a/src/main/resources/templates/book/admin/books.html
+++ b/src/main/resources/templates/book/admin/books.html
@@ -76,8 +76,8 @@
 
     try {
       // 서버로 PATCH 요청을 보냄
-      const response = await fetch('/admin/book/delete', {
-        method: 'PATCH',
+      const response = await fetch('/admin/book', {
+        method: 'DELETE',
         headers: {
           'Content-Type': 'application/json'
         },

--- a/src/main/resources/templates/bookreport/admin/book-report-detail.html
+++ b/src/main/resources/templates/bookreport/admin/book-report-detail.html
@@ -60,8 +60,8 @@
 
             try {
                 // 서버로 PATCH 요청을 보냄
-                const response = await fetch('/admin/book-report/delete', {
-                    method: 'PATCH',
+                const response = await fetch('/admin/book-report', {
+                    method: 'DELETE',
                     headers: {
                         'Content-Type': 'application/json'
                     },

--- a/src/main/resources/templates/bookreport/book-report-detail.html
+++ b/src/main/resources/templates/bookreport/book-report-detail.html
@@ -90,8 +90,8 @@
 
         try {
             // 서버로 PATCH 요청을 보냄
-            const response = await fetch('/book-report/delete', {
-                method: 'PATCH',
+            const response = await fetch('/book-report', {
+                method: 'DELETE',
                 headers: {
                     'Content-Type': 'application/json'
                 },


### PR DESCRIPTION
## feat&refactor: Book(도서) 생성자/수정자 연결 및 삭제 리팩토링(PATCH->DELETE)
- BookEntity의 createdBy는 다대일 관계 설정하지 않고(admin만 CUD하는 Entity이기에) admin 계정의 Member email만 넣자고 논의했던 부분 반영했습니다.
- @AuthenticationPrincipal 활용해서 생성자/수정자에 반영했습니다.
## feat: @AuthenticationPrincipal에서 가져온 로그인된 정보 MemberDTO로 Service에 전달
- 도서 생성/수정, 댓글 생성/수정 부분에 위 사항 반영했습니다.
- ReplyController의 CrossOrigin 어노테이션의 경우, 댓글이 정상적으로 수정됨에도 CORS 정책으로 인해 오류 메세지가 발생하는 부분을 해결하기 위해 삽입했습니다. 참고링크: https://wonit.tistory.com/572, https://inpa.tistory.com/entry/WEB-%F0%9F%93%9A-CORS-%F0%9F%92%AF-%EC%A0%95%EB%A6%AC-%ED%95%B4%EA%B2%B0-%EB%B0%A9%EB%B2%95-%F0%9F%91%8F
## refactor: BookReport(독후감) 삭제 관련 리팩토링(PATCH->DELETE)
- 아래 사항들은 이어서 바로 작업할 예정입니다.
  - 독후감에 MemberEntity 연결
  - 인증에 따라 독후감 수정/삭제 기능