### PR TITLE
[feat & refactor] BookReport(독후감) MemberEntity 연결 및 기타 리팩토링

### DIFF
--- a/src/main/java/com/kernel360/boogle/bookreport/controller/BookReportAdminController.java
+++ b/src/main/java/com/kernel360/boogle/bookreport/controller/BookReportAdminController.java
@@ -25,11 +25,6 @@ public class BookReportAdminController {
         ModelAndView mv = new ModelAndView("bookreport/admin/book-reports");
         Page<BookReportEntity> bookReports = bookReportService.getAllBookReports(page);
         mv.addObject("bookReports", bookReports);
-
-        int currentPageNumber = bookReports.getNumber();
-        int totalPagesNumber = bookReports.getTotalPages();
-        mv.addObject("currentPageNumber", currentPageNumber);
-        mv.addObject("totalPagesNumber", totalPagesNumber);
         return mv;
     }
 

--- a/src/main/java/com/kernel360/boogle/bookreport/controller/BookReportController.java
+++ b/src/main/java/com/kernel360/boogle/bookreport/controller/BookReportController.java
@@ -3,6 +3,8 @@ package com.kernel360.boogle.bookreport.controller;
 import com.kernel360.boogle.bookreport.db.BookReportEntity;
 import com.kernel360.boogle.bookreport.model.BookReportDTO;
 import com.kernel360.boogle.bookreport.service.BookReportService;
+import com.kernel360.boogle.member.db.MemberEntity;
+import com.kernel360.boogle.member.model.MemberDTO;
 import com.kernel360.boogle.reply.model.ReplyDTO;
 import com.kernel360.boogle.reply.model.ReplyResponse;
 import com.kernel360.boogle.reply.service.ReplyService;
@@ -11,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.ModelAndView;
 
@@ -38,8 +41,8 @@ public class BookReportController {
     }
 
     @PostMapping("/book-report")
-    public void createBookReport(@RequestBody BookReportDTO bookReport) {
-        bookReportService.createBookReport(bookReport);
+    public void createBookReport(@RequestBody BookReportDTO bookReport , @AuthenticationPrincipal MemberEntity memberEntity) {
+        bookReportService.createBookReport(bookReport, MemberDTO.from(memberEntity));
     }
 
     @GetMapping("/book-report")
@@ -91,8 +94,8 @@ public class BookReportController {
     }
 
     @PatchMapping("/book-report")
-    public void updateBookReport(@RequestBody BookReportDTO bookReport) {
-        bookReportService.updateBookReport(bookReport);
+    public void updateBookReport(@RequestBody BookReportDTO bookReport, @AuthenticationPrincipal MemberEntity memberEntity) {
+        bookReportService.updateBookReport(bookReport, MemberDTO.from(memberEntity));
     }
 
     @DeleteMapping("/book-report")

--- a/src/main/java/com/kernel360/boogle/bookreport/controller/BookReportController.java
+++ b/src/main/java/com/kernel360/boogle/bookreport/controller/BookReportController.java
@@ -64,10 +64,6 @@ public class BookReportController {
         ModelAndView mv = new ModelAndView("bookreport/book-reports");
         Page<BookReportEntity> bookReports = bookReportService.getMyBookReports(memberId, page);
         mv.addObject("bookReports", bookReports);
-        int currentPageNumber = bookReports.getNumber();
-        int totalPagesNumber = bookReports.getTotalPages();
-        mv.addObject("currentPageNumber", currentPageNumber);
-        mv.addObject("totalPagesNumber", totalPagesNumber);
         return mv;
     }
 
@@ -78,10 +74,6 @@ public class BookReportController {
         ModelAndView mv = new ModelAndView("bookreport/book-reports");
         Page<BookReportEntity> bookReports = bookReportService.getPublicBookReports("Y", page);
         mv.addObject("bookReports", bookReports);
-        int currentPageNumber = bookReports.getNumber();
-        int totalPagesNumber = bookReports.getTotalPages();
-        mv.addObject("currentPageNumber", currentPageNumber);
-        mv.addObject("totalPagesNumber", totalPagesNumber);
         return mv;
     }
 

--- a/src/main/java/com/kernel360/boogle/bookreport/db/BookReportEntity.java
+++ b/src/main/java/com/kernel360/boogle/bookreport/db/BookReportEntity.java
@@ -1,6 +1,7 @@
 package com.kernel360.boogle.bookreport.db;
 
 import com.kernel360.boogle.book.db.BookEntity;
+import com.kernel360.boogle.member.db.MemberEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -28,11 +29,9 @@ public class BookReportEntity {
     @JoinColumn(name = "book_id", nullable = false)
     private BookEntity bookEntity;
 
-//    @ManyToOne (멤버 엔티티 생성 이후 주석 해제 필요)
-//    @JoinColumn(name = "member_id", nullable = false)
-    @Column(name = "member_id")
-    private Long memberId;
-//    private MemberEntity memeberEntity;
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private MemberEntity memberEntity;
 
     @Column(name = "is_public", nullable = false)
     private String isPublic;

--- a/src/main/java/com/kernel360/boogle/bookreport/db/BookReportRepository.java
+++ b/src/main/java/com/kernel360/boogle/bookreport/db/BookReportRepository.java
@@ -12,7 +12,7 @@ public interface BookReportRepository extends JpaRepository<BookReportEntity, Lo
 
     Page<BookReportEntity> findAllByIsPublicOrderByIdDesc(String isPublic, Pageable pageable);
 
-    Page<BookReportEntity> findAllByMemberIdOrderByIdDesc(Long memberId, Pageable pageable);
+    Page<BookReportEntity> findAllByMemberEntity_IdOrderByIdDesc(Long memberId, Pageable pageable);
 
     Page<BookReportEntity> findAllByOrderByIdDesc(Pageable pageable);
 
@@ -20,7 +20,7 @@ public interface BookReportRepository extends JpaRepository<BookReportEntity, Lo
 
     List<BookReportEntity> findAllByBookEntity_IdAndIsPublicOrderByCreatedAtDesc(Long bookId, String isPublic);
 
-    List<BookReportEntity> findAllByMemberId(Long MemberId);
+    List<BookReportEntity> findAllByMemberEntity_Id(Long memberId);
 
     void deleteById(Long id);
 }

--- a/src/main/java/com/kernel360/boogle/bookreport/model/BookReportDTO.java
+++ b/src/main/java/com/kernel360/boogle/bookreport/model/BookReportDTO.java
@@ -2,6 +2,7 @@ package com.kernel360.boogle.bookreport.model;
 
 import com.kernel360.boogle.book.db.BookEntity;
 import com.kernel360.boogle.bookreport.db.BookReportEntity;
+import com.kernel360.boogle.member.db.MemberEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -16,8 +17,7 @@ import java.time.LocalDateTime;
 public class BookReportDTO {
     private Long id;
     private BookEntity bookEntity;
-    private Long memberId;
-    //    private MemberEntity memeberEntity;
+    private MemberEntity memberEntity;
     private String isPublic;
     private String title;
     private String content;

--- a/src/main/java/com/kernel360/boogle/bookreport/service/BookReportService.java
+++ b/src/main/java/com/kernel360/boogle/bookreport/service/BookReportService.java
@@ -4,13 +4,13 @@ import com.kernel360.boogle.bookreport.db.BookReportEntity;
 import com.kernel360.boogle.bookreport.db.BookReportRepository;
 import com.kernel360.boogle.bookreport.model.BookReportDTO;
 import com.kernel360.boogle.member.model.MemberDTO;
+import com.kernel360.boogle.reply.db.ReplyRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -19,11 +19,13 @@ import java.util.Optional;
 public class BookReportService {
 
     private final BookReportRepository bookReportRepository;
+    private final ReplyRepository replyRepository;
 
     private static final Integer PAGE_SIZE = 6;
 
-    public BookReportService(BookReportRepository bookReportRepository) {
+    public BookReportService(BookReportRepository bookReportRepository, ReplyRepository replyRepository) {
         this.bookReportRepository = bookReportRepository;
+        this.replyRepository = replyRepository;
     }
 
     public void createBookReport(BookReportDTO bookReport, MemberDTO memberDTO) {
@@ -62,7 +64,8 @@ public class BookReportService {
         bookReportRepository.save(bookReport.getBookReportEntity());
     }
 
-    public void deleteBookReport(Long bookReportId) {
+    public void deleteBookReport(Long bookReportId){
+        replyRepository.deleteAllByBookReportEntity_id(bookReportId);
         bookReportRepository.deleteById(bookReportId);
     }
 

--- a/src/main/java/com/kernel360/boogle/bookreport/service/BookReportService.java
+++ b/src/main/java/com/kernel360/boogle/bookreport/service/BookReportService.java
@@ -3,6 +3,7 @@ package com.kernel360.boogle.bookreport.service;
 import com.kernel360.boogle.bookreport.db.BookReportEntity;
 import com.kernel360.boogle.bookreport.db.BookReportRepository;
 import com.kernel360.boogle.bookreport.model.BookReportDTO;
+import com.kernel360.boogle.member.model.MemberDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -25,9 +26,9 @@ public class BookReportService {
         this.bookReportRepository = bookReportRepository;
     }
 
-    public void createBookReport(BookReportDTO bookReport) {
-        bookReport.getBookReportEntity().setCreatedBy("TEST"); // 로그인 사용자 정보 들어가야 함
-        bookReport.getBookReportEntity().setMemberId(1L); // 로그인 사용자 정보 들어가야 함
+    public void createBookReport(BookReportDTO bookReport, MemberDTO memberDTO) {
+        bookReport.getBookReportEntity().setCreatedBy(memberDTO.getEmail());
+        bookReport.getBookReportEntity().setMemberEntity(memberDTO.getMemberEntity());
         bookReportRepository.save(bookReport.getBookReportEntity());
     }
 
@@ -42,7 +43,7 @@ public class BookReportService {
 
     public Page<BookReportEntity> getMyBookReports(Long memberId, int page) {
         Pageable pageable = PageRequest.of(page, PAGE_SIZE);
-        return bookReportRepository.findAllByMemberIdOrderByIdDesc(memberId, pageable);
+        return bookReportRepository.findAllByMemberEntity_IdOrderByIdDesc(memberId, pageable);
     }
 
     public Page<BookReportEntity> getAllBookReports(int page) {
@@ -54,10 +55,10 @@ public class BookReportService {
         return bookReportRepository.findAllByBookEntity_IdAndIsPublicOrderByCreatedAtDesc(bookId,"Y");
     }
 
-    public void updateBookReport(BookReportDTO bookReport) {
-        bookReport.getBookReportEntity().setLastModifiedBy("TEST"); // 로그인 사용자 정보 들어가야 함
-        bookReport.getBookReportEntity().setMemberId(1L); // 로그인 사용자 정보 들어가야 함
-        bookReport.getBookReportEntity().setCreatedBy("TEST"); // 로그인 사용자 정보 들어가야 함
+    public void updateBookReport(BookReportDTO bookReport, MemberDTO memberDTO) {
+        bookReport.getBookReportEntity().setLastModifiedBy(memberDTO.getEmail());
+        bookReport.getBookReportEntity().setMemberEntity(memberDTO.getMemberEntity());
+        System.out.println("bookReport = " + bookReport);
         bookReportRepository.save(bookReport.getBookReportEntity());
     }
 
@@ -67,6 +68,6 @@ public class BookReportService {
 
 
     public List<BookReportEntity> getBookReportsByMemberId(Long memberId) {
-        return bookReportRepository.findAllByMemberId(memberId);
+        return bookReportRepository.findAllByMemberEntity_Id(memberId);
     }
 }

--- a/src/main/java/com/kernel360/boogle/reply/db/ReplyRepository.java
+++ b/src/main/java/com/kernel360/boogle/reply/db/ReplyRepository.java
@@ -2,10 +2,9 @@ package com.kernel360.boogle.reply.db;
 
 import com.kernel360.boogle.bookreport.db.BookReportEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.repository.query.Param;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -29,4 +28,6 @@ public interface ReplyRepository extends JpaRepository<ReplyEntity, Long> {
     List<ReplyEntity> findAllByMemberId(Long memberId, int cnt);
 
     void deleteById(Long id);
+
+    void deleteAllByBookReportEntity_id(Long booReportId);
 }

--- a/src/main/java/com/kernel360/boogle/reply/service/ReplyService.java
+++ b/src/main/java/com/kernel360/boogle/reply/service/ReplyService.java
@@ -24,9 +24,7 @@ public class ReplyService {
 
     public void createReply(ReplyDTO reply, MemberDTO memberDTO) {
 
-        if (reply.getReplyEntity().getContent().replaceAll("\\s", "").equals("")) {
-            throw new BusinessException(ReplyErrorCode.EMPTY_CONTENT_REPLY);
-        }
+        validateReplyContent(reply);
 
         reply.getReplyEntity().setMemberEntity(memberDTO.getMemberEntity());
         replyRepository.save(reply.getReplyEntity());
@@ -51,9 +49,7 @@ public class ReplyService {
 
     public void updateReply(ReplyDTO reply, MemberDTO memberDTO) {
 
-        if (reply.getReplyEntity().getContent().replaceAll("\\s", "").equals("")) {
-            throw new BusinessException(ReplyErrorCode.EMPTY_CONTENT_REPLY);
-        }
+        validateReplyContent(reply);
 
         reply.getReplyEntity().setMemberEntity(memberDTO.getMemberEntity());
         replyRepository.save(reply.getReplyEntity());
@@ -75,5 +71,11 @@ public class ReplyService {
                 .stream()
                 .map(ReplyDTO::from)
                 .toList();
+    }
+
+    private void validateReplyContent(ReplyDTO reply) {
+        if (reply.getReplyEntity().getContent().trim().isEmpty()) {
+            throw new BusinessException(ReplyErrorCode.EMPTY_CONTENT_REPLY);
+        }
     }
 }

--- a/src/main/resources/templates/book/admin/book-create.html
+++ b/src/main/resources/templates/book/admin/book-create.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
   <!-- Font Awesome 스타일시트 추가 -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.3/css/all.css">
+  <title>Boogle</title>
   <link href="./../../css/styles.css" rel="stylesheet" />
   <!-- 추가적인 CSS 스타일 추가 -->
   <style>

--- a/src/main/resources/templates/book/admin/book-update.html
+++ b/src/main/resources/templates/book/admin/book-update.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
   <!-- Font Awesome 스타일시트 추가 -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.3/css/all.css">
+  <title>Boogle</title>
   <link href="./../../css/styles.css" rel="stylesheet" />
   <!-- 추가적인 CSS 스타일 추가 -->
   <style>

--- a/src/main/resources/templates/book/admin/books.html
+++ b/src/main/resources/templates/book/admin/books.html
@@ -10,6 +10,7 @@
 
   <!-- Font Awesome 스타일시트 추가 -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.3/css/all.css">
+  <title>Boogle</title>
   <link href="./../../css/styles.css" rel="stylesheet" />
 
   <!-- 추가적인 CSS 스타일 추가 -->

--- a/src/main/resources/templates/book/admin/books.html
+++ b/src/main/resources/templates/book/admin/books.html
@@ -70,6 +70,12 @@
 <body>
 <script>
   async function deleteBook(bookId) {
+    const confirmed = confirm('정말로 이 도서를 삭제하시겠습니까?');
+
+    if (!confirmed) {
+      return;
+    }
+
     // JSON 데이터를 생성
     let data = {
       id: bookId

--- a/src/main/resources/templates/book/book-detail.html
+++ b/src/main/resources/templates/book/book-detail.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <meta name="description" content="" />
     <meta name="author" content="" />
-    <title>Blog Home - Start Bootstrap Template</title>
+    <title>Boogle</title>
     <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
     <link href="css/styles.css" rel="stylesheet" />
 </head>

--- a/src/main/resources/templates/book/books.html
+++ b/src/main/resources/templates/book/books.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <meta name="description" content="" />
     <meta name="author" content="" />
-    <title>Blog Home - Start Bootstrap Template</title>
+    <title>Boogle</title>
     <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
     <link href="css/styles.css" rel="stylesheet" />
 </head>

--- a/src/main/resources/templates/bookreport/admin/book-report-detail.html
+++ b/src/main/resources/templates/bookreport/admin/book-report-detail.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
     <!-- Font Awesome 스타일시트 추가 -->
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.3/css/all.css">
+    <title>Boogle</title>
     <link href="./../../css/styles.css" rel="stylesheet" />
     <!-- 추가적인 CSS 스타일 추가 -->
     <style>

--- a/src/main/resources/templates/bookreport/admin/book-report-detail.html
+++ b/src/main/resources/templates/bookreport/admin/book-report-detail.html
@@ -55,6 +55,12 @@
     </style>
     <script type="text/javascript">
         async function deleteBookReport() {
+            const confirmed = confirm('정말로 이 독후감을 삭제하시겠습니까?');
+
+            if (!confirmed) {
+                return;
+            }
+
             let data = {
                 id: document.getElementById('id').value
             };

--- a/src/main/resources/templates/bookreport/admin/book-reports.html
+++ b/src/main/resources/templates/bookreport/admin/book-reports.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.3/css/all.css">
+    <title>Boogle</title>
     <link href="./../../css/styles.css" rel="stylesheet" />
     <style>
         body {

--- a/src/main/resources/templates/bookreport/book-report-create.html
+++ b/src/main/resources/templates/bookreport/book-report-create.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <meta name="description" content="" />
     <meta name="author" content="" />
-    <title>Write a Book Review - Start Bootstrap Template</title>
+    <title>Boogle</title>
     <!-- Favicon-->
     <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
     <!-- Core theme CSS (includes Bootstrap)-->

--- a/src/main/resources/templates/bookreport/book-report-detail.html
+++ b/src/main/resources/templates/bookreport/book-report-detail.html
@@ -83,6 +83,12 @@
     }
 
     async function deleteBookReport(bookReportId) {
+        const confirmed = confirm('정말로 이 독후감을 삭제하시겠습니까?');
+
+        if (!confirmed) {
+            return;
+        }
+
         // JSON 데이터를 생성
         let data = {
             id: bookReportId
@@ -114,6 +120,12 @@
     }
 
     async function deleteReply(replyId) {
+        const confirmed = confirm('정말로 이 댓글을 삭제하시겠습니까?');
+
+        if (!confirmed) {
+            return;
+        }
+
         // JSON 데이터를 생성
         let data = {
             id: replyId

--- a/src/main/resources/templates/bookreport/book-report-detail.html
+++ b/src/main/resources/templates/bookreport/book-report-detail.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <meta name="description" content="" />
     <meta name="author" content="" />
-    <title>Blog Post - Start Bootstrap Template</title>
+    <title>Boogle</title>
     <!-- Favicon-->
     <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
     <!-- Core theme CSS (includes Bootstrap)-->
@@ -142,21 +142,6 @@
             alert('댓글 삭제 중 오류가 발생했습니다.');
             alert(error);
         }
-
-        // let xhr = new XMLHttpRequest();
-        // xhr.open('DELETE', '/reply', true);
-        // xhr.setRequestHeader('Content-Type', 'application/json; charset=UTF-8');
-        //
-        // xhr.onload = function() {
-        //     if (xhr.status === 200) {
-        //         alert('댓글이 성공적으로 삭제되었습니다.');
-        //         window.location.href = '/book-report?id=' + document.getElementById('bookReportId').value;
-        //     } else {
-        //         alert('댓글 삭제 중 오류가 발생했습니다.');
-        //     }
-        // };
-        //
-        // xhr.send(JSON.stringify(data));
     }
 
     function updateBookReport(bookReportId) {
@@ -180,7 +165,7 @@
                         <!-- Post meta content -->
                         <div class="text-muted fst-italic mb-2" th:text="'Posted on ' + ${#temporals.format(bookReport.createdAt, 'yyyy년 MM월 dd일 HH:mm')} + ' by ' + '멤버 DB 추가 시, 연결 필요합니다.'"></div>
                     </header>
-                    <div class="col-4 text-end">
+                    <div class="col-4 text-end" th:if="${#authorization.expression('isAuthenticated()')} and ${bookReport.memberEntity.getId} == ${#authentication.principal.id}">
                         <!-- Submit button -->
                         <button type="button" class="btn btn-primary" th:onclick="|updateBookReport(${bookReport.id});|">수정</button>
                         <button type="button" class="btn btn-danger" th:onclick="|deleteBookReport(${bookReport.id});|">삭제</button>

--- a/src/main/resources/templates/bookreport/book-report-update.html
+++ b/src/main/resources/templates/bookreport/book-report-update.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <meta name="description" content="" />
     <meta name="author" content="" />
-    <title>Write a Book Review - Start Bootstrap Template</title>
+    <title>Boogle</title>
     <!-- Favicon-->
     <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
     <!-- Core theme CSS (includes Bootstrap)-->
@@ -19,7 +19,8 @@
                 title: document.getElementById('title').value,
                 bookEntity: {id: document.getElementById('bookId').value},
                 content: document.getElementById('content').value,
-                isPublic: document.getElementById('isPrivate').checked === true ? 'N' : 'Y'
+                isPublic: document.getElementById('isPrivate').checked === true ? 'N' : 'Y',
+                createdBy: document.getElementById('createdBy').value
             }
         };
 
@@ -73,6 +74,7 @@
                     <label class="form-check-label" for="isPrivate">비공개</label>
                 </div>
                 <input type="hidden" id="id" name="id" th:value="${bookReport.id}">
+                <input type="hidden" id="createdBy" name="created-by" th:value="${bookReport.createdBy}">
                 <!-- Submit button -->
                 <button type="button" class="btn btn-primary" th:onclick="|updateBookReport();|">수정</button>
                 <button type="button" class="btn btn-secondary" th:onclick="|cancel();|">취소</button>

--- a/src/main/resources/templates/bookreport/book-reports.html
+++ b/src/main/resources/templates/bookreport/book-reports.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <meta name="description" content="" />
     <meta name="author" content="" />
-    <title>Blog Home - Start Bootstrap Template</title>
+    <title>Boogle</title>
     <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
     <link href="css/styles.css" rel="stylesheet" />
 </head>
@@ -100,7 +100,7 @@
                     <div class="col-md-6 d-flex flex-column justify-content-center">
                         <div class="text-center mb-2">
                             <h2 class="card-title h4" th:text="${bookReport.title}"></h2>
-                            <p class="card-text" th:text="${bookReport.content}"></p>
+                            <p class="card-text" th:text="${bookReport.memberEntity.getNickname}"></p>
                         </div>
                         <div class="text-center mb-3">
                             <div class="small text-muted" th:text="${#temporals.format(bookReport.createdAt, 'yyyy년 MM월 dd일 HH:mm')}"></div>

--- a/src/main/resources/templates/bookreport/book-reports.html
+++ b/src/main/resources/templates/bookreport/book-reports.html
@@ -119,8 +119,8 @@
 
     <!-- Pagination-->
     <nav aria-label="Pagination">
-        <input type="hidden" id="currentPage" name="currentPage" th:value="${currentPageNumber}">
-        <input type="hidden" id="totalPages" name="totalPages" th:value="${totalPagesNumber}">
+        <input type="hidden" id="currentPage" name="currentPage" th:value="${bookReports.getNumber()}">
+        <input type="hidden" id="totalPages" name="totalPages" th:value="${bookReports.getTotalPages()}">
         <hr class="my-3 center" />
         <ul class="pagination justify-content-center">
             <li th:if="${bookReports.hasPrevious()}" class="page-item">

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -6,7 +6,7 @@
 fit=no" />
     <meta name="description" content="" />
     <meta name="author" content="" />
-    <title>Boogle Login</title>
+    <title>Boogle</title>
     <link rel="icon" type="image/x-icon" th:href="@{/assets/favicon.ico}" />
     <link th:href="@{/css/styles.css}" rel="stylesheet" />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">

--- a/src/main/resources/templates/mypage/bookReport.html
+++ b/src/main/resources/templates/mypage/bookReport.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <meta name="description" content="" />
     <meta name="author" content="" />
-    <title>Blog Home - Start Bootstrap Template</title>
+    <title>Boogle</title>
     <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
     <link href="../css/styles.css" rel="stylesheet" />
 </head>

--- a/src/main/resources/templates/mypage/communityReply.html
+++ b/src/main/resources/templates/mypage/communityReply.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <meta name="description" content="" />
     <meta name="author" content="" />
-    <title>Blog Home - Start Bootstrap Template</title>
+    <title>Boogle</title>
     <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
     <link href="../css/styles.css" rel="stylesheet" />
 </head>

--- a/src/main/resources/templates/mypage/main.html
+++ b/src/main/resources/templates/mypage/main.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
     <meta name="description" content=""/>
     <meta name="author" content=""/>
-    <title>Blog Home - Start Bootstrap Template</title>
+    <title>Boogle</title>
     <link rel="icon" type="image/x-icon" href="assets/favicon.ico"/>
     <link href="../css/styles.css" rel="stylesheet"/>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -5,7 +5,7 @@
       layout:decorate="~{layout/basic.html}">
 <head>
     <meta charset="UTF-8">
-    <title>Title</title>
+    <title>Boogle</title>
     <script layout:fragment="script" th:inline="javascript">
         const auth = [[${#authentication.principal}]]
         const errors = [[${errors}]]

--- a/src/main/resources/templates/statistics/admin/statistics-admin-dashboard.html
+++ b/src/main/resources/templates/statistics/admin/statistics-admin-dashboard.html
@@ -10,6 +10,7 @@
 
   <!-- Font Awesome 스타일시트 추가 -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.3/css/all.css">
+  <title>Boogle</title>
   <link href="./../../css/styles.css" rel="stylesheet" />
 
   <!-- 추가적인 CSS 스타일 추가 -->

--- a/src/test/java/com/kernel360/boogle/bookreport/db/BookReportRepositoryTest.java
+++ b/src/test/java/com/kernel360/boogle/bookreport/db/BookReportRepositoryTest.java
@@ -1,11 +1,11 @@
 package com.kernel360.boogle.bookreport.db;
 
 import com.kernel360.boogle.book.db.BookRepository;
+import com.kernel360.boogle.member.db.MemberRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.BDDAssertions.then;
@@ -20,11 +20,14 @@ class BookReportRepositoryTest {
     @Autowired
     BookRepository bookRepository;
 
+    @Autowired
+    MemberRepository memberRepository;
+
     @Test
     void save() {
         BookReportEntity bookReport = BookReportEntity.builder()
                 .bookEntity(bookRepository.findById(4L).get())
-                .memberId(1L)
+                .memberEntity(memberRepository.findById(1L).get())
                 .isPublic("Y")
                 .title("test report")
                 .content("test content")
@@ -40,9 +43,8 @@ class BookReportRepositoryTest {
     }
 
     @Test
-    void findAllByIsPublicEqualsAndIsDeletedNotOrderByIdDesc() {
-        then(bookReportRepository.findAllByIsPublicEqualsAndIsDeletedNotOrderByIdDesc(
-                "Y",
+    void findAllByIsPublicOrderByIdDesc() {
+        then(bookReportRepository.findAllByIsPublicOrderByIdDesc(
                 "Y",
                 PageRequest.of(0, 6)
         ).getContent().size()).isEqualTo(6);
@@ -50,20 +52,17 @@ class BookReportRepositoryTest {
 
 
     @Test
-    void findAllByMemberIdEqualsAndIsDeletedNotOrderByIdDesc() {
-        then(bookReportRepository.findAllByMemberIdEqualsAndIsDeletedNotOrderByIdDesc(
+    void findAllByMemberIdOrderByIdDesc() {
+        then(bookReportRepository.findAllByMemberEntity_IdOrderByIdDesc(
                 1L,
-                "Y",
                 PageRequest.of(0, 6)
         ).getContent().size()).isEqualTo(6);
     }
 
     @Test
-    void findAllByIsDeletedNotOrderByIdDesc() {
-        then(bookReportRepository.findAllByIsDeletedNotOrderByIdDesc(
-                "Y",
-                PageRequest.of(0, 6)
-        ).getContent().size()).isEqualTo(6);
+    void findAllByOrderByIdDesc() {
+        then(bookReportRepository.findAllByOrderByIdDesc(PageRequest.of(0, 6))
+                .getContent().size()).isEqualTo(6);
     }
 
     @Test

--- a/src/test/java/com/kernel360/boogle/bookreport/service/BookReportServiceTest.java
+++ b/src/test/java/com/kernel360/boogle/bookreport/service/BookReportServiceTest.java
@@ -4,11 +4,13 @@ import com.kernel360.boogle.book.db.BookRepository;
 import com.kernel360.boogle.bookreport.db.BookReportEntity;
 import com.kernel360.boogle.bookreport.db.BookReportRepository;
 import com.kernel360.boogle.bookreport.model.BookReportDTO;
+import com.kernel360.boogle.member.db.MemberEntity;
+import com.kernel360.boogle.member.db.MemberRepository;
+import com.kernel360.boogle.member.model.MemberDTO;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
@@ -28,14 +30,19 @@ class BookReportServiceTest {
     private BookReportRepository bookReportRepository;
 
     @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
     private BookReportService bookReportService;
 
     @Test
     void createBookReport() {
         long rowCount = bookReportRepository.count();
+        MemberEntity member = memberRepository.findById(1L).get();
         BookReportDTO bookReportDTO = BookReportDTO.builder()
                 .bookReportEntity(
                         BookReportEntity.builder()
+                                .memberEntity(member)
                                 .bookEntity(bookRepository.findById(54L).get())
                                 .isPublic("N")
                                 .title("타이틀1")
@@ -43,7 +50,7 @@ class BookReportServiceTest {
                                 .build()
                 )
                 .build();
-        bookReportService.createBookReport(bookReportDTO);
+        bookReportService.createBookReport(bookReportDTO, MemberDTO.from(member));
         assertEquals(bookReportRepository.count(), rowCount + 1);
     }
 
@@ -87,6 +94,7 @@ class BookReportServiceTest {
 
     @Test
     void updateBookReport() {
+        MemberEntity member = memberRepository.findById(1L).get();
         BookReportDTO bookReportDTO = BookReportDTO.builder()
                 .bookReportEntity(
                     BookReportEntity.builder()
@@ -98,7 +106,7 @@ class BookReportServiceTest {
                         .build()
                 )
                 .build();
-        bookReportService.updateBookReport(bookReportDTO);
+        bookReportService.updateBookReport(bookReportDTO, MemberDTO.from(member));
         assertThat(bookReportRepository.findById(1L).get().getIsPublic()).isEqualTo("N");
     }
 
@@ -106,6 +114,6 @@ class BookReportServiceTest {
     void deleteBookReport() {
         Long bookReportId = 1L;
         bookReportService.deleteBookReport(bookReportId);
-        assertThat(bookReportRepository.findById(bookReportId).get().getIsDeleted()).isEqualTo("Y");
+        assertThat(bookReportRepository.findById(bookReportId).isEmpty());
     }
 }


### PR DESCRIPTION
#### commit한 순으로 변경내용 정리했습니다. 보실 때, files changed 말고 commits 기준으로 보시면 더 편하실 듯 합니다!
---
## BookReport(독후감) MemberEntity 연결 관련 feat & refactor
1. feat
  - 기존에 하드코딩되어있던 부분을, 현재 Member 정보로 생성/수정되도록 변경했습니다.
  - 유저 화면에서 자신이 작성한 독후감 상세페이지에서만 수정/삭제 버튼이 보이도록 수정했습니다.
2. refactor: BookReport(독후감) MemberEntity 연결로 인한 BookReportTest 수정
3. refactor: BookReport(독후감) Controller 페이징 addObject 코드 제거 
    - #138 이슈에 작성된 내용을 바탕으로, addObject로 Controller에서 따로 보내지 않고, 화면에서 직접 bookReports의 현재 페이지와 전체 페이지 수를 꺼내 쓰도록 변경했습니다.
## 기타 feat & refactor
  4. refactor: Reply(댓글/대댓글) 빈 내용 입력 오류 처리 코드 변경 
    - #138 이슈에 작성된 내용을 바탕으로 리팩토링 했습니다.
    - 공백으로 입력하는 에러 판단 조건을 trim으로 구현했습니다.
    - 판단하는 코드가 중복되기에, validateReplyContent로 메서드분리 했습니다.
  5. refactor: html header title "Boogle"로 통일
    - 기본 템플릿 형식으로 돼있던 title(브라우저 탭에 표시되는 이름)을 전부 Boogle로 수정했습니다.
  6. refactor: 삭제 시, 삭제여부 확인하는 절차 추가
    - https://github.com/Kernel360/E2E1-Boogle/issues/138 이슈에 작성된 바와 같이, 도서/독후감/댓글 삭제 시, 삭제할 것인지 물어보는 절차를 추가했습니다.
  7. feat: 독후감 삭제 시, 해당 독후감에 달린 댓글도 삭제
    - 기존에는 댓글이 달린 독후감이 삭제가 안되는 오류가 있었습니다.
    - BookReportService에서 삭제 수행 시, 해당 BookReport에 달린 댓글을 삭제하는 deleteAllByBookReportEntity_id 절차를 추가했습니다.