### PR TITLE
[feat] 독후감 작성 & 마이페이지 기능 고도화

### DIFF
--- a/src/main/java/com/kernel360/boogle/bookreport/service/BookReportService.java
+++ b/src/main/java/com/kernel360/boogle/bookreport/service/BookReportService.java
@@ -60,7 +60,6 @@ public class BookReportService {
     public void updateBookReport(BookReportDTO bookReport, MemberDTO memberDTO) {
         bookReport.getBookReportEntity().setLastModifiedBy(memberDTO.getEmail());
         bookReport.getBookReportEntity().setMemberEntity(memberDTO.getMemberEntity());
-        System.out.println("bookReport = " + bookReport);
         bookReportRepository.save(bookReport.getBookReportEntity());
     }
 

--- a/src/main/resources/templates/bookreport/book-report-create.html
+++ b/src/main/resources/templates/bookreport/book-report-create.html
@@ -80,11 +80,12 @@
                         var listItem = $('<li class="list-group-item">')
                             .text(book.title)
                             .data('book-id', book.id)
+                            .data('book-title', book.title)
                             .click(function () {
-                                selectedBookId = $(this).data('book-id');
                                 $('.list-group-item').removeClass('selected-book');
                                 $(this).addClass('selected-book');
                                 $('#bookId').val($(this).data('book-id'));
+                                $('#bookTitle').val($(this).data('book-title'));
                             })
                             .appendTo(bookSearchResults);
                     });
@@ -118,9 +119,10 @@
                 </div>
                 <!-- Book ID input with "Find Book" button -->
                 <div class="mb-3">
-                    <label for="bookId" class="form-label">도서 ID</label>
+                    <label for="bookId" class="form-label">도서</label>
                     <div class="input-group">
-                        <input type="text" class="form-control" id="bookId" placeholder="도서 ID를 입력하세요">
+                        <input type="text" class="form-control" id="bookTitle" placeholder="'도서 찾기'를 통해 도서를 입력해 주세요">
+                        <input type="hidden" class="form-control" id="bookId">
                         <button type="button" class="btn btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#bookSearchModal">도서 찾기</button>
                     </div>
                 </div>

--- a/src/main/resources/templates/mypage/main.html
+++ b/src/main/resources/templates/mypage/main.html
@@ -94,11 +94,16 @@
         }
 
         .scrollable-table {
-            height: 300px; /* Adjust as needed */
+            height: 350px; /* Adjust as needed */
             overflow-y: auto;
         }
     </style>
 </head>
+<script>
+    function navigateToBookReport(bookReportId) {
+        window.location.href = '/book-report?id=' + bookReportId;
+    }
+</script>
 <body style="position: relative; min-height: 100vh;">
 <nav th:replace="~{fragments/navbar :: navbarFragment}"></nav>
 <div class="heading">Welcome to Mypage!</div>
@@ -153,7 +158,7 @@
         </tr>
         </thead>
         <tbody>
-        <tr th:each="reply : ${replies}">
+        <tr th:each="reply : ${replies}" th:onclick="|navigateToBookReport(${reply.bookReportEntity.id})|">
             <td th:text="${reply.bookReportEntity.title}">책 제목</td>
             <td th:text="${reply.content}">내용</td>
             <td th:text="${#temporals.format(reply.createdAt, 'yyyy-MM-dd')}">작성일</td>
@@ -181,7 +186,7 @@
                     <p>작성된 독후감이 없습니다.</p>
                 </div>
                 <tbody>
-                <tr th:each="bookReport : ${bookReports}">
+                <tr th:each="bookReport : ${bookReports}" th:onclick="|navigateToBookReport(${bookReport.id})|">
                     <td th:text="${bookReport.bookEntity.title}">책 제목</td>
                     <td th:text="${bookReport.title}">독후감 제목</td>
                     <td th:text="${bookReport.content}">독후감 내용</td>


### PR DESCRIPTION
### feat: BookReport(독후감) 작성 시, 도서 id 말고 도서 제목이 뜨도록 변경
  - 독후감 작성 시, [도서 찾기] 모달창에서 도서를 선택하면 기존 화면에서 도서 id가 반영됐었습니다.
  - 이 부분을 더욱 명시적으로 확인할 수 있도록, 화면에 도서 제목이 반영되도록 수정했습니다.
### feat: MyPage(마이페이지) Main 화면에서 댓글/독후감 클릭 시, 해당 독후감 링크로 이동
  - 기존에는 클릭해도 아무 반응이 없었던 것을, 해당 댓글/독후감이 작성된 독후감 링크로 이동하도록 구현했습니다.